### PR TITLE
Add backend Id as identifier instead of url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pem
 .vscode
+.DS_Store

--- a/internal/domain/backend.go
+++ b/internal/domain/backend.go
@@ -1,12 +1,25 @@
 package domain
 
+import "sync"
+
+var (
+	idCounter uint64
+	idMutex   sync.Mutex
+)
+
 type Backend struct {
+	Id     uint64
 	URL    string
 	Health string
 }
 
-func NewBackend(url, health string) *Backend {
+func NewBackend(url string, health string) *Backend {
+	idMutex.Lock()
+	idCounter++
+	id := idCounter
+	idMutex.Unlock()
 	return &Backend{
+		Id:     id,
 		URL:    url,
 		Health: health,
 	}

--- a/internal/domain/backend_registry.go
+++ b/internal/domain/backend_registry.go
@@ -2,7 +2,7 @@ package domain
 
 type BackendRegistry interface {
 	UpdateHealth(status BackendStatus) error
-	Subscribe(backendUrl string) <-chan BackendStatus
+	Subscribe(backendId uint64) <-chan BackendStatus
 	GetBackendById(backendId uint64) (Backend, bool)
 	AddBackendToRegistry(backend Backend)
 }

--- a/internal/domain/backend_registry.go
+++ b/internal/domain/backend_registry.go
@@ -3,6 +3,6 @@ package domain
 type BackendRegistry interface {
 	UpdateHealth(status BackendStatus) error
 	Subscribe(backendUrl string) <-chan BackendStatus
-	GetBackendByURL(backendUrl string) (Backend, bool)
+	GetBackendById(backendId uint64) (Backend, bool)
 	AddBackendToRegistry(backend Backend)
 }

--- a/internal/domain/backend_status.go
+++ b/internal/domain/backend_status.go
@@ -1,6 +1,7 @@
 package domain
 
 type BackendStatus struct {
+	Id        uint64
 	URL       string
 	IsHealthy bool
 }

--- a/internal/domain/backend_status.go
+++ b/internal/domain/backend_status.go
@@ -2,6 +2,5 @@ package domain
 
 type BackendStatus struct {
 	Id        uint64
-	URL       string
 	IsHealthy bool
 }

--- a/internal/infrastructure/backend_registry.go
+++ b/internal/infrastructure/backend_registry.go
@@ -11,7 +11,7 @@ type healthUpdateChannel chan domain.BackendStatus
 
 type BackendRegistry struct {
 	mu          sync.RWMutex
-	backendUrl  map[string]domain.Backend        // backendUrl -> domain.Backend
+	backendId   map[uint64]domain.Backend        //backendId -> domain.Backend
 	backends    map[string]domain.BackendStatus  // Store backend health status
 	subscribers map[string][]healthUpdateChannel // Map of backend -> list of load balancer channel
 }
@@ -19,7 +19,7 @@ type BackendRegistry struct {
 // Initialize the registry
 func NewBackendRegistry() *BackendRegistry {
 	return &BackendRegistry{
-		backendUrl:  make(map[string]domain.Backend),
+		backendId:   make(map[uint64]domain.Backend),
 		backends:    make(map[string]domain.BackendStatus),
 		subscribers: make(map[string][]healthUpdateChannel),
 	}
@@ -58,15 +58,16 @@ func (r *BackendRegistry) Subscribe(backendUrl string) <-chan domain.BackendStat
 	return ch
 }
 
-func (r *BackendRegistry) GetBackendByURL(backendUrl string) (domain.Backend, bool) {
+// Get the backend with id
+func (r *BackendRegistry) GetBackendById(backendId uint64) (domain.Backend, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	backend, exists := r.backendUrl[backendUrl]
+	backend, exists := r.backendId[backendId]
 	return backend, exists
 }
 
 func (r *BackendRegistry) AddBackendToRegistry(backend domain.Backend) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.backendUrl[backend.URL] = backend
+	r.backendId[backend.Id] = backend
 }

--- a/internal/infrastructure/backend_registry.go
+++ b/internal/infrastructure/backend_registry.go
@@ -12,16 +12,16 @@ type healthUpdateChannel chan domain.BackendStatus
 type BackendRegistry struct {
 	mu          sync.RWMutex
 	backendId   map[uint64]domain.Backend        //backendId -> domain.Backend
-	backends    map[string]domain.BackendStatus  // Store backend health status
-	subscribers map[string][]healthUpdateChannel // Map of backend -> list of load balancer channel
+	backends    map[uint64]domain.BackendStatus  // Store backend health status
+	subscribers map[uint64][]healthUpdateChannel // Map of backend -> list of load balancer channel
 }
 
 // Initialize the registry
 func NewBackendRegistry() *BackendRegistry {
 	return &BackendRegistry{
 		backendId:   make(map[uint64]domain.Backend),
-		backends:    make(map[string]domain.BackendStatus),
-		subscribers: make(map[string][]healthUpdateChannel),
+		backends:    make(map[uint64]domain.BackendStatus),
+		subscribers: make(map[uint64][]healthUpdateChannel),
 	}
 }
 
@@ -33,10 +33,10 @@ func (r *BackendRegistry) UpdateHealth(status domain.BackendStatus) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.backends[status.URL] = status
+	r.backends[status.Id] = status
 
 	// Notify all lbs of this backend health update
-	if subs, ok := r.subscribers[status.URL]; ok {
+	if subs, ok := r.subscribers[status.Id]; ok {
 		for _, ch := range subs {
 			ch <- status // Non-blocking send
 		}
@@ -45,7 +45,7 @@ func (r *BackendRegistry) UpdateHealth(status domain.BackendStatus) error {
 }
 
 // Method for load balancers to subscribe to specific backend health updates
-func (r *BackendRegistry) Subscribe(backendUrl string) <-chan domain.BackendStatus {
+func (r *BackendRegistry) Subscribe(backendId uint64) <-chan domain.BackendStatus {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -53,7 +53,7 @@ func (r *BackendRegistry) Subscribe(backendUrl string) <-chan domain.BackendStat
 	ch := make(chan domain.BackendStatus, 10)
 
 	// Add the channel to the list of subscribers for the backend
-	r.subscribers[backendUrl] = append(r.subscribers[backendUrl], ch)
+	r.subscribers[backendId] = append(r.subscribers[backendId], ch)
 
 	return ch
 }

--- a/internal/usecases/health_checker.go
+++ b/internal/usecases/health_checker.go
@@ -83,14 +83,14 @@ func (hc *HealthChecker) updateBackendStatus(backend *domain.Backend, isHealthy 
 	if isHealthy {
 		if !exists {
 			hc.healthySet.Store(backend.URL, backend)
-			statusUpdate := &domain.BackendStatus{URL: backend.URL, IsHealthy: isHealthy}
+			statusUpdate := &domain.BackendStatus{Id: backend.Id, URL: backend.URL, IsHealthy: isHealthy}
 			hc.registry.UpdateHealth(*statusUpdate) // Notify immediately on change
 			hc.logger.Info("Backend moved to healthy", zap.String("backend_url", backend.URL))
 		}
 	} else {
 		if exists {
 			hc.healthySet.Delete(backend.URL)
-			statusUpdate := &domain.BackendStatus{URL: backend.URL, IsHealthy: isHealthy}
+			statusUpdate := &domain.BackendStatus{Id: backend.Id, URL: backend.URL, IsHealthy: isHealthy}
 			hc.registry.UpdateHealth(*statusUpdate) // Notify immediately on change
 			hc.logger.Info("Backend moved to unhealthy", zap.String("backend_url", backend.URL))
 		}

--- a/internal/usecases/health_checker.go
+++ b/internal/usecases/health_checker.go
@@ -83,14 +83,14 @@ func (hc *HealthChecker) updateBackendStatus(backend *domain.Backend, isHealthy 
 	if isHealthy {
 		if !exists {
 			hc.healthySet.Store(backend.URL, backend)
-			statusUpdate := &domain.BackendStatus{Id: backend.Id, URL: backend.URL, IsHealthy: isHealthy}
+			statusUpdate := &domain.BackendStatus{Id: backend.Id, IsHealthy: isHealthy}
 			hc.registry.UpdateHealth(*statusUpdate) // Notify immediately on change
 			hc.logger.Info("Backend moved to healthy", zap.String("backend_url", backend.URL))
 		}
 	} else {
 		if exists {
 			hc.healthySet.Delete(backend.URL)
-			statusUpdate := &domain.BackendStatus{Id: backend.Id, URL: backend.URL, IsHealthy: isHealthy}
+			statusUpdate := &domain.BackendStatus{Id: backend.Id, IsHealthy: isHealthy}
 			hc.registry.UpdateHealth(*statusUpdate) // Notify immediately on change
 			hc.logger.Info("Backend moved to unhealthy", zap.String("backend_url", backend.URL))
 		}

--- a/internal/usecases/health_checker_test.go
+++ b/internal/usecases/health_checker_test.go
@@ -27,7 +27,7 @@ func (m *MockBackendRegistry) Subscribe(backendUrl string) <-chan domain.Backend
 	return nil
 }
 
-func (m *MockBackendRegistry) GetBackendByURL(backendUrl string) (domain.Backend, bool) {
+func (m *MockBackendRegistry) GetBackendById(backendId uint64) (domain.Backend, bool) {
 	return domain.Backend{}, false
 }
 

--- a/internal/usecases/health_checker_test.go
+++ b/internal/usecases/health_checker_test.go
@@ -23,7 +23,7 @@ func (m *MockBackendRegistry) UpdateHealth(status domain.BackendStatus) error {
 	return nil
 }
 
-func (m *MockBackendRegistry) Subscribe(backendUrl string) <-chan domain.BackendStatus {
+func (m *MockBackendRegistry) Subscribe(backendId uint64) <-chan domain.BackendStatus {
 	return nil
 }
 
@@ -35,6 +35,7 @@ func (m *MockBackendRegistry) AddBackendToRegistry(backend domain.Backend) {}
 
 func setupTest(t *testing.T, healthyBackend bool, markAsHealthy bool) (*MockBackendRegistry, *HealthChecker, *httptest.Server, *domain.Backend) {
 	testBackend := &domain.Backend{
+		Id:     11,
 		URL:    "http://test-backend",
 		Health: "/health",
 	}
@@ -87,7 +88,7 @@ func TestHealthChecker_BackendBecomesAlive(t *testing.T) {
 	}
 
 	// Verify that the correct backend status was passed to UpdateHealth
-	expectedStatus := domain.BackendStatus{URL: testBackend.URL, IsHealthy: true}
+	expectedStatus := domain.BackendStatus{Id: 11, IsHealthy: true}
 	if mockRegistry.updatedStatus != expectedStatus {
 		t.Errorf("Expected UpdateHealth to be called with %+v, but got %+v", expectedStatus, mockRegistry.updatedStatus)
 	}
@@ -143,7 +144,7 @@ func TestHealthChecker_BackendBecomesUnhealthy(t *testing.T) {
 	}
 
 	// Verify the correct backend status was passed to UpdateHealth.
-	expectedStatus := domain.BackendStatus{URL: testBackend.URL, IsHealthy: false}
+	expectedStatus := domain.BackendStatus{Id: 11, IsHealthy: false}
 	if mockRegistry.updatedStatus != expectedStatus {
 		t.Errorf("Expected UpdateHealth to be called with %+v, but got %+v", expectedStatus, mockRegistry.updatedStatus)
 	}

--- a/internal/usecases/loadbalancing/load_balancer.go
+++ b/internal/usecases/loadbalancing/load_balancer.go
@@ -64,35 +64,35 @@ func (lb *LoadBalancer) listenToHealthUpdates() {
 
 func (lb *LoadBalancer) updateProcessDispatcher(update domain.BackendStatus) {
 	if update.IsHealthy {
-		lb.addToHealthyBackends(update.URL)
+		lb.addToHealthyBackends(update.Id)
 	} else {
-		lb.removeFromHealthyBackends(update.URL)
+		lb.removeFromHealthyBackends(update.Id)
 	}
 }
 
-func (lb *LoadBalancer) addToHealthyBackends(backendURL string) {
+func (lb *LoadBalancer) addToHealthyBackends(backendId uint64) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
 	for _, backend := range lb.healthyBackends {
-		if backend.URL == backendURL {
+		if backend.Id == backendId {
 			return
 		}
 	}
-	backend, ok := lb.backendRegistry.GetBackendByURL(backendURL)
+	backend, ok := lb.backendRegistry.GetBackendById(backendId)
 	if !ok {
-		lb.logger.Error("No backend forund for url", zap.String("backend_url", backendURL))
+		lb.logger.Error("No backend forund for url", zap.Uint64("backend_id", backendId))
 		return
 	}
 	lb.healthyBackends = append(lb.healthyBackends, &backend)
 }
 
-func (lb *LoadBalancer) removeFromHealthyBackends(backendURL string) {
+func (lb *LoadBalancer) removeFromHealthyBackends(backendId uint64) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
 	for i, backend := range lb.healthyBackends {
-		if backend.URL == backendURL {
+		if backend.Id == backendId {
 			lb.healthyBackends = append(lb.healthyBackends[:i], lb.healthyBackends[i+1:]...)
 			return
 		}

--- a/internal/usecases/loadbalancing/load_balancer.go
+++ b/internal/usecases/loadbalancing/load_balancer.go
@@ -54,7 +54,7 @@ func (lb *LoadBalancer) listenToHealthUpdates() {
 		chosen, value, ok := reflect.Select(cases)
 		if ok {
 			update := value.Interface().(domain.BackendStatus)
-			lb.logger.Debug("Received backend health update", zap.String("backend_url", update.URL))
+			lb.logger.Debug("Received backend health update", zap.Uint64("backend_id", update.Id))
 			lb.updateProcessDispatcher(update)
 		} else {
 			lb.logger.Warn("BackendHealthUpdateChannel was closed", zap.Int("update_channel", chosen))

--- a/internal/usecases/loadbalancing/load_balancer_factory.go
+++ b/internal/usecases/loadbalancing/load_balancer_factory.go
@@ -27,18 +27,18 @@ func CreateLoadBalancers(config *infrastructure.Config, registry *infrastructure
 func setupHealthAndRegister(backends []infrastructure.Backend, registry *infrastructure.BackendRegistry, healthChecker *usecases.HealthChecker) []<-chan domain.BackendStatus {
 	var healthUpdateChannels []<-chan domain.BackendStatus
 	for _, backendConfig := range backends {
-		// Subscribe for health updates
-		channel := registry.Subscribe(backendConfig.URL)
-		healthUpdateChannels = append(healthUpdateChannels, channel)
-
 		// Register the backend with health checker and registry
-		registerBackend(backendConfig, registry, healthChecker)
+		backend := registerBackend(backendConfig, registry, healthChecker)
+		// Subscribe for health updates
+		channel := registry.Subscribe(backend.Id)
+		healthUpdateChannels = append(healthUpdateChannels, channel)
 	}
 	return healthUpdateChannels
 }
 
-func registerBackend(backendConfig infrastructure.Backend, registry *infrastructure.BackendRegistry, healthChecker *usecases.HealthChecker) {
+func registerBackend(backendConfig infrastructure.Backend, registry *infrastructure.BackendRegistry, healthChecker *usecases.HealthChecker) *domain.Backend {
 	backend := domain.NewBackend(backendConfig.URL, backendConfig.Health)
 	healthChecker.AddBackend(backend)
 	registry.AddBackendToRegistry(*backend)
+	return backend
 }


### PR DESCRIPTION
Added backend id as identifier for backends instead of URL. Backend ids are created right with a counter placed in Backend, with a mutex to protect it. In the future it can be improved by assigning a range for each thread (currently it is single threaded and backend ids are only assigned at startup from configuration).

Updated backend registry, loadbalncer and healthchecker to use backend Id as identifier.